### PR TITLE
Discrepancy in Accumulative Swing Index 

### DIFF
--- a/lib/accumulative_swing_index.js
+++ b/lib/accumulative_swing_index.js
@@ -48,7 +48,7 @@ class AccumulativeSwingIndex extends Indicator {
       er = prevClose.minus(low)
     }
 
-    const r = tr.minus((er.times(0.5)).plus(sh.times(0.25)))
+    const r = tr.minus(er.times(0.5)).plus(sh.times(0.25))
 
     if (r.isEqualTo(0)) {
       return 0

--- a/test/accumulative_swing_index.spec.js
+++ b/test/accumulative_swing_index.spec.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const test = require('tape')
+const ASI = require('../lib/accumulative_swing_index')
+
+const candles = [
+  {
+    'open': 6373, 
+    'high': 6375.9,
+    'low': 6369.2,
+    'close': 6374.5,
+  },
+  {
+    'open': 6408.8,
+    'high': 6408.9,
+    'low': 6366,
+    'close': 6372.9,
+  }
+]
+
+test('ASI is calculated properly', (t) => {
+  const asi = new ASI([6400]);
+
+  asi.add(candles[0]);
+  asi.add(candles[1]);
+  t.equal(asi.v().toFixed(13), '-0.1190821779318')
+})


### PR DESCRIPTION
Resolves https://github.com/bitfinexcom/bfx-hf-strategy-py/issues/2

Included is a test that returns exactly same value for python and js impls, but feel free to ignore it if you don't like it.