### PR TITLE
2.0.0: Fixes & Wilders MA

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const Indicator = require('./lib/indicator')
 const SMA = require('./lib/sma')
 const EMA = require('./lib/ema')
+const WildersMA = require('./lib/wilders_ma')
 const MACD = require('./lib/macd')
 const RSI = require('./lib/rsi')
 const ROC = require('./lib/roc')
@@ -51,6 +52,7 @@ module.exports = {
   Indicator,
   SMA,
   EMA,
+  WildersMA,
   MACD,
   RSI,
   Momentum,

--- a/lib/accumulation_distribution.js
+++ b/lib/accumulation_distribution.js
@@ -23,12 +23,12 @@ class AccumulationDistribution extends Indicator {
   }
 
   update (candle) {
-    const { high, low, close, vol } = candle
+    const { high, low, close, volume } = candle
     const moneyFlowMult = high === low
       ? 0
       : ((close - low) - (high - close)) / (high - low)
 
-    const moneyFlowVol = moneyFlowMult * vol
+    const moneyFlowVol = moneyFlowMult * volume
     const prev = this.prev()
 
     return super.update(_isFinite(prev)
@@ -38,12 +38,12 @@ class AccumulationDistribution extends Indicator {
   }
 
   add (candle) {
-    const { high, low, close, vol } = candle
+    const { high, low, close, volume } = candle
     const moneyFlowMult = high === low
       ? 0
       : ((close - low) - (high - close)) / (high - low)
 
-    const moneyFlowVol = moneyFlowMult * vol
+    const moneyFlowVol = moneyFlowMult * volume
     const prev = this.v()
 
     return super.add(_isFinite(prev)

--- a/lib/alma.js
+++ b/lib/alma.js
@@ -6,13 +6,15 @@ const Indicator = require('./indicator')
 
 class ALMA extends Indicator {
   constructor (args = []) {
-    const [ period, offset, sigma ] = args
+    const [ period, offset, sigma, dataKey = 'close' ] = args
 
     super({
       args,
       id: ALMA.id,
       name: `ALMA(${period}, ${offset}, ${sigma})`,
-      seedPeriod: period
+      seedPeriod: period,
+      dataType: 'candle',
+      dataKey,
     })
 
     this._p = period

--- a/lib/aroon.js
+++ b/lib/aroon.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const _isFinite = require('lodash/isFinite')
 const _isEmpty = require('lodash/isEmpty')
 const _max = require('lodash/max')
 const _min = require('lodash/min')

--- a/lib/chaikin_money_flow.js
+++ b/lib/chaikin_money_flow.js
@@ -33,20 +33,20 @@ class CMF extends Indicator {
   }
 
   update (candle) {
-    const { high, low, close, vol } = candle
+    const { high, low, close, volume } = candle
     const mf = high === low
       ? 0
       : ((close - low) - (high - close)) / (high - low)
-    const mfv = mf * vol
+    const mfv = mf * volume
 
     if (this._bufferVol.length === 0) {
-      this._bufferVol.push(vol)
+      this._bufferVol.push(volume)
     } else {
-      this._bufferVol[this._bufferVol.length - 1] = vol
+      this._bufferVol[this._bufferVol.length - 1] = volume
     }
 
     if (this._bufferMFV.length === 0) {
-      this._bufferMFV.push(vol)
+      this._bufferMFV.push(volume)
     } else {
       this._bufferMFV[this._bufferMFV.length - 1] = mfv
     }
@@ -59,14 +59,14 @@ class CMF extends Indicator {
   }
 
   add (candle) {
-    const { high, low, close, vol } = candle
+    const { high, low, close, volume } = candle
     const mf = high === low
       ? 0
       : ((close - low) - (high - close)) / (high - low)
 
-    const mfv = mf * vol
+    const mfv = mf * volume
 
-    this._bufferVol.push(vol)
+    this._bufferVol.push(volume)
     this._bufferMFV.push(mfv)
 
     if (this._bufferVol.length > this._p) {

--- a/lib/chande_momentum_oscillator.js
+++ b/lib/chande_momentum_oscillator.js
@@ -42,13 +42,13 @@ class ChandeMO extends Indicator {
       return
     }
 
-    const sU = new BigN(_sum(this._buffer
+    const sU = new BigN(`${_sum(this._buffer
       .filter(({ open, close }) => close > open)
-      .map(({ open, close }) => close - open)))
+      .map(({ open, close }) => close - open))}`)
 
-    const sD = new BigN(_sum(this._buffer
+    const sD = new BigN(`${_sum(this._buffer
       .filter(({ open, close }) => close < open)
-      .map(({ open, close }) => open - close)))
+      .map(({ open, close }) => open - close))}`)
 
     return super.update(sU.minus(sD).div(sU.plus(sD)).times(100).toNumber())
   }
@@ -62,13 +62,13 @@ class ChandeMO extends Indicator {
       return
     }
 
-    const sU = new BigN(_sum(this._buffer
+    const sU = new BigN(`${_sum(this._buffer
       .filter(({ open, close }) => close > open)
-      .map(({ open, close }) => close - open)))
+      .map(({ open, close }) => close - open))}`)
 
-    const sD = new BigN(_sum(this._buffer
+    const sD = new BigN(`${_sum(this._buffer
       .filter(({ open, close }) => close < open)
-      .map(({ open, close }) => open - close)))
+      .map(({ open, close }) => open - close))}`)
 
     return super.add(sU.minus(sD).div(sU.plus(sD)).times(100).toNumber())
   }

--- a/lib/donchian_channels.js
+++ b/lib/donchian_channels.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const _isObject = require('lodash/isObject')
 const _max = require('lodash/max')
 const _min = require('lodash/min')
 const Indicator = require('./indicator')

--- a/lib/ease_of_movement.js
+++ b/lib/ease_of_movement.js
@@ -43,7 +43,7 @@ class EOM extends Indicator {
 
     const high = new BigN(candle.high)
     const low = new BigN(candle.low)
-    const vol = new BigN(candle.vol)
+    const vol = new BigN(candle.volume)
     const lastHigh = new BigN(this._lastCandle.high)
     const lastLow = new BigN(this._lastCandle.low)
 
@@ -69,7 +69,7 @@ class EOM extends Indicator {
 
     const high = new BigN(candle.high)
     const low = new BigN(candle.low)
-    const vol = new BigN(candle.vol)
+    const vol = new BigN(candle.volume)
     const lastHigh = new BigN(this._lastCandle.high)
     const lastLow = new BigN(this._lastCandle.low)
 

--- a/lib/ema.js
+++ b/lib/ema.js
@@ -5,13 +5,15 @@ const Indicator = require('./indicator')
 
 class EMA extends Indicator {
   constructor (args = []) {
-    const [ period ] = args
+    const [ period, dataKey = 'close' ] = args
 
     super({
       args,
       id: EMA.id,
       name: `EMA(${period})`,
-      seedPeriod: period
+      seedPeriod: period,
+      dataType: 'candle',
+      dataKey
     })
 
     this._a = 2 / (period + 1)
@@ -49,6 +51,9 @@ EMA.ui = {
 EMA.args = [{
   label: 'Period',
   default: 20
+}, {
+  label: 'Candle Key',
+  default: 'close',
 }]
 
 module.exports = EMA

--- a/lib/ema_vol.js
+++ b/lib/ema_vol.js
@@ -31,9 +31,9 @@ class EMAVolume extends Indicator {
   }
 
   update (candle) {
-    const { vol } = candle
+    const { volume } = candle
 
-    this._ema.update(vol)
+    this._ema.update(volume)
     const ema = this._ema.v()
 
     if (_isFinite(ema)) {
@@ -44,9 +44,9 @@ class EMAVolume extends Indicator {
   }
 
   add (candle) {
-    const { vol } = candle
+    const { volume } = candle
 
-    this._ema.add(vol)
+    this._ema.add(volume)
     const ema = this._ema.v()
 
     if (_isFinite(ema)) {

--- a/lib/envelope.js
+++ b/lib/envelope.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const _isObject = require('lodash/isObject')
 const _isFinite = require('lodash/isFinite')
 const Indicator = require('./indicator')
 const SMA = require('./sma')

--- a/lib/macd.js
+++ b/lib/macd.js
@@ -39,12 +39,12 @@ class MACD extends Indicator {
     const macd = fastEMA - slowEMA
     const signalEMA = this._signalEMA.update(macd)
 
-    const histogram = macd - signalEMA
+    const divergence = macd - signalEMA
 
     return super.update({
       macd: macd,
       signal: signalEMA,
-      histogram: histogram
+      divergence: divergence
     })
   }
 
@@ -55,12 +55,12 @@ class MACD extends Indicator {
     const macd = fastEMA - slowEMA
     const signalEMA = this._signalEMA.add(macd)
 
-    const histogram = macd - signalEMA
+    const divergence = macd - signalEMA
 
     return super.add({
       macd: macd,
       signal: signalEMA,
-      histogram: histogram
+      divergence: divergence
     })
   }
 
@@ -73,7 +73,7 @@ MACD.id = 'macd'
 MACD.label = 'MACD'
 MACD.humanLabel = 'Moving Average Convergence Divergence'
 MACD.ui = {
-  position: 'overlay',
+  position: 'external',
   type: 'macd'
 }
 

--- a/lib/net_volume.js
+++ b/lib/net_volume.js
@@ -19,22 +19,22 @@ class NetVolume extends Indicator {
   }
 
   update (candle) {
-    const { open, close, vol } = candle
+    const { open, close, volume } = candle
 
     if (close >= open) {
-      return super.update(vol)
+      return super.update(volume)
     } else {
-      return super.update(-vol)
+      return super.update(-volume)
     }
   }
 
   add (candle) {
-    const { open, close, vol } = candle
+    const { open, close, volume } = candle
 
     if (close >= open) {
-      return super.add(vol)
+      return super.add(volume)
     } else {
-      return super.add(-vol)
+      return super.add(-volume)
     }
   }
 }

--- a/lib/on_balance_volume.js
+++ b/lib/on_balance_volume.js
@@ -31,14 +31,14 @@ class OBV extends Indicator {
       return this.v()
     }
 
-    const { close, vol } = candle
+    const { close, volume } = candle
     const v = this.l() > 1 ? this.prev() : 0
     let obv = v
 
     if (close > this._lastCandle.close) {
-      obv = v + vol
+      obv = v + volume
     } else if (close < this._lastCandle.close) {
-      obv = v - vol
+      obv = v - volume
     }
 
     return super.update(obv)
@@ -50,14 +50,14 @@ class OBV extends Indicator {
       return this.v()
     }
 
-    const { close, vol } = candle
+    const { close, volume } = candle
     const v = this.l() > 0 ? this.v() : 0
     let obv = v
 
     if (close > this._lastCandle.close) {
-      obv = v + vol
+      obv = v + volume
     } else if (close < this._lastCandle.close) {
-      obv = v - vol
+      obv = v - volume
     }
 
     super.add(obv)

--- a/lib/price_channel.js
+++ b/lib/price_channel.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const _isObject = require('lodash/isObject')
 const Indicator = require('./indicator')
 const _min = require('lodash/min')
 const _max = require('lodash/max')

--- a/lib/price_volume_trend.js
+++ b/lib/price_volume_trend.js
@@ -31,8 +31,8 @@ class PVT extends Indicator {
       return this.v()
     }
 
-    const { close, vol } = candle
-    const pvt = ((close - this._lastCandle.close) / this._lastCandle.close) * vol
+    const { close, volume } = candle
+    const pvt = ((close - this._lastCandle.close) / this._lastCandle.close) * volume
     const v = this.l() > 1 ? this.prev() : 0
 
     return super.update(pvt + v)
@@ -44,8 +44,8 @@ class PVT extends Indicator {
       return this.v()
     }
 
-    const { close, vol } = candle
-    const pvt = ((close - this._lastCandle.close) / this._lastCandle.close) * vol
+    const { close, volume } = candle
+    const pvt = ((close - this._lastCandle.close) / this._lastCandle.close) * volume
     const v = this.l() > 0 ? this.v() : 0
 
     super.add(pvt + v)

--- a/lib/relative_vigor_index.js
+++ b/lib/relative_vigor_index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const _isObject = require('lodash/isObject')
 const BigN = require('bignumber.js')
 const SMA = require('./sma')
 const Indicator = require('./indicator')

--- a/lib/relative_vigor_index.js
+++ b/lib/relative_vigor_index.js
@@ -37,16 +37,16 @@ class RVGI extends Indicator {
 
   static calc (candle, buffer) {
     const { open, close, high, low } = candle
-    const barA = new BigN(close - open)
-    const barB = new BigN(buffer[2].close - buffer[2].open)
-    const barC = new BigN(buffer[1].close - buffer[1].open)
-    const barD = new BigN(buffer[0].close - buffer[0].open)
+    const barA = new BigN(`${close - open}`)
+    const barB = new BigN(`${buffer[2].close - buffer[2].open}`)
+    const barC = new BigN(`${buffer[1].close - buffer[1].open}`)
+    const barD = new BigN(`${buffer[0].close - buffer[0].open}`)
     const num = barA.plus(barB.times(2)).plus(barC.times(2)).plus(barD).div(6)
 
-    const e = new BigN(high - low)
-    const f = new BigN(buffer[2].high - buffer[2].low)
-    const g = new BigN(buffer[1].high - buffer[1].low)
-    const h = new BigN(buffer[0].high - buffer[0].low)
+    const e = new BigN(`${high - low}`)
+    const f = new BigN(`${buffer[2].high - buffer[2].low}`)
+    const g = new BigN(`${buffer[1].high - buffer[1].low}`)
+    const h = new BigN(`${buffer[0].high - buffer[0].low}`)
     const den = e.plus(f.times(2)).plus(g.times(2)).plus(h).div(6)
 
     return {
@@ -75,11 +75,11 @@ class RVGI extends Indicator {
     let signal = 0
 
     if (this.l() >= 3) {
-      const i = new BigN(this.v().rvi)
-      const j = new BigN(this.prev(1).rvi)
-      const k = new BigN(this.prev(2).rvi)
+      const i = new BigN(`${this.v().rvi}`)
+      const j = new BigN(`${this.prev(1).rvi}`)
+      const k = new BigN(`${this.prev(2).rvi}`)
 
-      signal = new BigN(rvi).plus(i.times(2)).plus(j.times(2)).plus(k).div(6).toNumber()
+      signal = new BigN(`${rvi}`).plus(i.times(2)).plus(j.times(2)).plus(k).div(6).toNumber()
     }
 
     return super.update({ rvi, signal })
@@ -103,11 +103,11 @@ class RVGI extends Indicator {
     let signal = 0
 
     if (this.l() >= 4) {
-      const i = new BigN(this.prev(1).rvi)
-      const j = new BigN(this.prev(2).rvi)
-      const k = new BigN(this.prev(3).rvi)
+      const i = new BigN(`${this.prev(1).rvi}`)
+      const j = new BigN(`${this.prev(2).rvi}`)
+      const k = new BigN(`${this.prev(3).rvi}`)
 
-      signal = new BigN(rvi).plus(i.times(2)).plus(j.times(2)).plus(k).div(6).toNumber()
+      signal = new BigN(`${rvi}`).plus(i.times(2)).plus(j.times(2)).plus(k).div(6).toNumber()
     }
 
     return super.add({ rvi, signal })

--- a/lib/rsi.js
+++ b/lib/rsi.js
@@ -2,7 +2,7 @@
 
 const _isFinite = require('lodash/isFinite')
 const Indicator = require('./indicator')
-const MA = require('./sma')
+const MA = require('./wilders_ma')
 
 class RSI extends Indicator {
   constructor (args = []) {

--- a/lib/rsi.js
+++ b/lib/rsi.js
@@ -2,7 +2,7 @@
 
 const _isFinite = require('lodash/isFinite')
 const Indicator = require('./indicator')
-const EMA = require('./ema')
+const MA = require('./sma')
 
 class RSI extends Indicator {
   constructor (args = []) {
@@ -16,8 +16,8 @@ class RSI extends Indicator {
     })
 
     this._p = period
-    this._uEMA = new EMA([period])
-    this._dEMA = new EMA([period])
+    this._uMA = new MA([period])
+    this._dMA = new MA([period])
     this._prevInputValue = null
   }
 
@@ -30,8 +30,8 @@ class RSI extends Indicator {
 
     this._prevInputValue = null
 
-    if (this._uEMA) this._uEMA.reset()
-    if (this._dEMA) this._dEMA.reset()
+    if (this._uMA) this._uMA.reset()
+    if (this._dMA) this._dMA.reset()
   }
 
   _ud (value) {
@@ -46,8 +46,8 @@ class RSI extends Indicator {
   }
 
   _rs () {
-    const uAvg = this._uEMA.v()
-    const dAvg = this._dEMA.v()
+    const uAvg = this._uMA.v()
+    const dAvg = this._dMA.v()
 
     return !_isFinite(uAvg) || !_isFinite(dAvg) || dAvg === 0
       ? null
@@ -61,8 +61,8 @@ class RSI extends Indicator {
 
     const { u, d } = this._ud(value)
 
-    this._uEMA.update(u)
-    this._dEMA.update(d)
+    this._uMA.update(u)
+    this._dMA.update(d)
 
     const rs = this._rs()
 
@@ -80,8 +80,8 @@ class RSI extends Indicator {
 
     const { u, d } = this._ud(value)
 
-    this._uEMA.add(u)
-    this._dEMA.add(d)
+    this._uMA.add(u)
+    this._dMA.add(d)
 
     const rs = this._rs()
 

--- a/lib/rsi.js
+++ b/lib/rsi.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const BigN = require('bignumber.js')
 const _isFinite = require('lodash/isFinite')
 const Indicator = require('./indicator')
 const MA = require('./wilders_ma')
@@ -15,7 +16,6 @@ class RSI extends Indicator {
       seedPeriod: period
     })
 
-    this._p = period
     this._uMA = new MA([period])
     this._dMA = new MA([period])
     this._prevInputValue = null
@@ -40,8 +40,8 @@ class RSI extends Indicator {
       : value - this._prevInputValue
 
     return {
-      u: delta > 0 ? delta : 0,
-      d: delta < 0 ? delta * -1 : 0
+      u: new BigN(delta > 0 ? delta : 0),
+      d: new BigN(delta < 0 ? delta * -1 : 0)
     }
   }
 
@@ -51,7 +51,7 @@ class RSI extends Indicator {
 
     return !_isFinite(uAvg) || !_isFinite(dAvg) || dAvg === 0
       ? null
-      : uAvg / dAvg
+      : new BigN(uAvg).div(new BigN(dAvg))
   }
 
   update (value) {
@@ -61,13 +61,13 @@ class RSI extends Indicator {
 
     const { u, d } = this._ud(value)
 
-    this._uMA.update(u)
-    this._dMA.update(d)
+    this._uMA.update(u.toNumber())
+    this._dMA.update(d.toNumber())
 
     const rs = this._rs()
 
-    if (_isFinite(rs)) {
-      super.update(100 - (100 / (1 + rs)))
+    if (rs !== null) {
+      super.update(new BigN(100).minus(new BigN(100).div(new BigN(1).plus(rs))).toNumber())
     }
 
     return this.v()
@@ -80,13 +80,13 @@ class RSI extends Indicator {
 
     const { u, d } = this._ud(value)
 
-    this._uMA.add(u)
-    this._dMA.add(d)
+    this._uMA.add(u.toNumber())
+    this._dMA.add(d.toNumber())
 
     const rs = this._rs()
 
-    if (_isFinite(rs)) {
-      super.add(100 - (100 / (1 + rs)))
+    if (rs !== null) {
+      super.add(new BigN(100).minus(new BigN(100).div(new BigN(1).plus(rs))).toNumber())
       this._prevInputValue = value
     }
 

--- a/lib/stochastic_rsi.js
+++ b/lib/stochastic_rsi.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const _isFinite = require('lodash/isFinite')
+const _isObject = require('lodash/isObject')
 const _min = require('lodash/min')
 const _max = require('lodash/max')
 const Indicator = require('./indicator')

--- a/lib/true_strength_index.js
+++ b/lib/true_strength_index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const _isObject = require('lodash/isObject')
 const _max = require('lodash/max')
 
 const Indicator = require('./indicator')

--- a/lib/volume_oscillator.js
+++ b/lib/volume_oscillator.js
@@ -32,10 +32,10 @@ class VO extends Indicator {
   }
 
   update (candle) {
-    const { vol } = candle
+    const { volume } = candle
 
-    this._shortEMA.update(vol)
-    this._longEMA.update(vol)
+    this._shortEMA.update(volume)
+    this._longEMA.update(volume)
 
     const short = this._shortEMA.v()
     const long = this._longEMA.v()
@@ -48,10 +48,10 @@ class VO extends Indicator {
   }
 
   add (candle) {
-    const { vol } = candle
+    const { volume } = candle
 
-    this._shortEMA.add(vol)
-    this._longEMA.add(vol)
+    this._shortEMA.add(volume)
+    this._longEMA.add(volume)
 
     const short = this._shortEMA.v()
     const long = this._longEMA.v()

--- a/lib/vwap.js
+++ b/lib/vwap.js
@@ -34,27 +34,27 @@ class VWAP extends Indicator {
   }
 
   update (candle) {
-    const { high, low, close, vol } = candle
+    const { high, low, close, volume } = candle
     const typ = (high + low + close) / 3
 
     this._totalDen = this._lastDen
     this._totalNum = this._lastNum
 
-    this._totalNum += typ * vol
-    this._totalDen += vol
+    this._totalNum += typ * volume
+    this._totalDen += volume
 
     return super.update(this._totalNum / this._totalDen)
   }
 
   add (candle) {
-    const { high, low, close, vol } = candle
+    const { high, low, close, volume } = candle
     const typ = (high + low + close) / 3
 
     this._lastNum = this._totalNum
     this._lastDen = this._totalDen
 
-    this._totalNum += typ * vol
-    this._totalDen += vol
+    this._totalNum += typ * volume
+    this._totalDen += volume
 
     return super.add(this._totalNum / this._totalDen)
   }

--- a/lib/vwma.js
+++ b/lib/vwma.js
@@ -47,13 +47,13 @@ class VWMA extends Indicator {
     let sum = new BigN(0)
 
     for (let i = 0; i < this._buffer.length; i += 1) {
-      volSum = volSum.plus(new BigN(this._buffer[i].vol))
+      volSum = volSum.plus(new BigN(this._buffer[i].volume))
     }
 
     for (let i = 0; i < this._buffer.length; i += 1) {
       c = this._buffer[i]
 
-      sum = sum.plus(new BigN(c.close).times(new BigN(c.vol).div(volSum)))
+      sum = sum.plus(new BigN(c.close).times(new BigN(c.volume).div(volSum)))
     }
 
     return super.update(sum.toNumber())
@@ -73,13 +73,13 @@ class VWMA extends Indicator {
     let sum = new BigN(0)
 
     for (let i = 0; i < this._buffer.length; i += 1) {
-      volSum = volSum.plus(new BigN(this._buffer[i].vol))
+      volSum = volSum.plus(new BigN(this._buffer[i].volume))
     }
 
     for (let i = 0; i < this._buffer.length; i += 1) {
       c = this._buffer[i]
 
-      sum = sum.plus(new BigN(c.close).times(new BigN(c.vol).div(volSum)))
+      sum = sum.plus(new BigN(c.close).times(new BigN(c.volume).div(volSum)))
     }
 
     return super.add(sum.toNumber())

--- a/lib/wilders_ma.js
+++ b/lib/wilders_ma.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const BigN = require('bignumber.js')
 const _last = require('lodash/last')
 const Indicator = require('./indicator')
 
@@ -16,11 +17,11 @@ class WildersMA extends Indicator {
       dataKey
     })
 
-    this._a = 1 / period
+    this._a = new BigN(1).div(new BigN(period))
   }
 
   static unserialize (args = []) {
-    return new EMA(args)
+    return new WildersMA(args)
   }
 
   update (v) {
@@ -28,14 +29,22 @@ class WildersMA extends Indicator {
       return super.update(v)
     }
 
-    return super.update((this._a * v) + ((1 - this._a) * this.prev()))
+    return super.update(
+      this._a.times(new BigN(v)).plus(
+        (new BigN(1).minus(this._a).times(this.prev()))
+      ).toNumber()
+    )
   }
 
   add (v) {
     if (this.l() === 0) {
       return super.add(v)
     } else {
-      return super.add((this._a * v) + ((1 - this._a) * _last(this._values)))
+      return super.add(
+        this._a.times(new BigN(v)).plus(
+          (new BigN(1).minus(this._a).times(_last(this._values)))
+        ).toNumber()
+      )
     }
   }
 }

--- a/lib/wilders_ma.js
+++ b/lib/wilders_ma.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const _last = require('lodash/last')
+const Indicator = require('./indicator')
+
+class WildersMA extends Indicator {
+  constructor (args = []) {
+    const [ period, dataKey = 'close' ] = args
+
+    super({
+      args,
+      id: WildersMA.id,
+      name: `Wilder MA(${period})`,
+      seedPeriod: period,
+      dataType: 'candle',
+      dataKey
+    })
+
+    this._a = 1 / period
+  }
+
+  static unserialize (args = []) {
+    return new EMA(args)
+  }
+
+  update (v) {
+    if (this.l() < 2) {
+      return super.update(v)
+    }
+
+    return super.update((this._a * v) + ((1 - this._a) * this.prev()))
+  }
+
+  add (v) {
+    if (this.l() === 0) {
+      return super.add(v)
+    } else {
+      return super.add((this._a * v) + ((1 - this._a) * _last(this._values)))
+    }
+  }
+}
+
+WildersMA.id = 'wilderma'
+WildersMA.label = 'Wilder MA'
+WildersMA.humanLabel = 'Wilders Moving Average'
+WildersMA.ui = {
+  position: 'overlay',
+  type: 'line'
+}
+
+WildersMA.args = [{
+  label: 'Period',
+  default: 20
+}, {
+  label: 'Candle Key',
+  default: 'close',
+}]
+
+module.exports = WildersMA

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-indicators",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A library of trading indicators for Node.JS",
   "main": "./dist/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-indicators",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "A library of trading indicators for Node.JS",
   "main": "./dist/index.js",
   "directories": {


### PR DESCRIPTION
Bump to 2.0.0

### Changes
* Renames `vol` -> `volume` on candles (the usual name on data sources)
* Exposes `candleKey` in ALMA args
* Adds Wilders MA
* RSI now uses Wilders MA internally
* Use `BigN` in some places/cast to string before passing
* Fix missing imports on some indicators
* Updates MACD key names for compatbility w/ `react-stockcharts`