### PR TITLE
added methods to check if the indicator is seeded

### DIFF
--- a/lib/ema.js
+++ b/lib/ema.js
@@ -45,6 +45,14 @@ class EMA extends Indicator {
     this._buffer = []
   }
 
+  isSeeded () {
+    return !!this._buffer.length
+  }
+
+  bl () {
+    return this._buffer.length
+  }
+
   v () {
     if (this.l() === 0) {
       return null

--- a/lib/sma.js
+++ b/lib/sma.js
@@ -16,10 +16,19 @@ class SMA extends Indicator {
     })
 
     this._p = period
+    this._buffer = []
   }
 
   static unserialize (args = []) {
     return new SMA(args)
+  }
+
+  isSeeded () {
+    return !!this._buffer.length
+  }
+
+  bl () {
+    return this._buffer.length
   }
 
   v () {

--- a/test/ema.js
+++ b/test/ema.js
@@ -45,15 +45,24 @@ describe('Exponential Moving Average(EMA)', () => {
     assert.deepStrictEqual(ema.v().toFixed(3), '6386.383')
   })
 
+  it('checks if the indicator is seeded', () => {
+    const ema = new EMA(emaPeriod)
+    assert.ok(!ema.isSeeded(), 'should not have seeded the indicator')
+    ema.add(100)
+    assert.ok(ema.isSeeded(), 'should have seeded the indicator')
+    ema.reset()
+    assert.ok(!ema.isSeeded(), 'should have cleared the seeded values in indicator after reset')
+  })
+
   it('empties the buffer and ema values on reset', () => {
     const ema = new EMA(emaPeriod)
     candles.forEach(c => ema.add(c.close))
     assert.deepStrictEqual(ema.v().toFixed(3), '6386.383')
-    assert.deepStrictEqual(ema._buffer.length, 3)
-    assert.deepStrictEqual(ema._values.length, 2)
+    assert.deepStrictEqual(ema.bl(), 3)
+    assert.deepStrictEqual(ema.l(), 2)
     ema.reset()
-    assert.deepStrictEqual(ema._buffer.length, 0)
-    assert.deepStrictEqual(ema._values.length, 0)
+    assert.deepStrictEqual(ema.bl(), 0)
+    assert.deepStrictEqual(ema.l(), 0)
   })
 
   it('returns ema as null if the given time period is less than the provided candles', () => {

--- a/test/sma.js
+++ b/test/sma.js
@@ -31,11 +31,20 @@ describe('Simple Moving Average(SMA)', () => {
     assert.deepStrictEqual(sma.v(), 6381)
   })
 
+  it('checks if the indicator is seeded', () => {
+    const sma = new SMA(smaPeriod)
+    assert.ok(!sma.isSeeded(), 'should not have seeded the indicator')
+    sma.add(100)
+    assert.ok(sma.isSeeded(), 'should have seeded the indicator')
+    sma.reset()
+    assert.ok(!sma.isSeeded(), 'should have cleared the seeded values in indicator after reset')
+  })
+
   it('empties the buffer on reset', () => {
     const sma = new SMA(smaPeriod)
     sma.add(candles[0].close)
     sma.reset()
-    assert.deepStrictEqual(sma._buffer.length, 0)
+    assert.deepStrictEqual(sma.bl(), 0)
   })
 
   it('calculates sma based on the updated value', () => {


### PR DESCRIPTION
Since, ema values aren't calculated unless we have enough candles for the given timeframe, we need an extra function to check if the indicator is seeded or not for passing individual candle prices.
 
- Added method in ma indicators to check if the indicator is seeded or not
- Added method in ma indicators to fetch the length of the buffer

### Description:
...

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
